### PR TITLE
Layer adjustment before the max layer is set

### DIFF
--- a/src/FastRouteKernel.cpp
+++ b/src/FastRouteKernel.cpp
@@ -1094,7 +1094,7 @@ unsigned FastRouteKernel::getDbId() {
 }
 
 void FastRouteKernel::addLayerAdjustment(int layer, float reductionPercentage) {
-        if (layer > _maxRoutingLayer) {
+        if (layer > _maxRoutingLayer && _maxRoutingLayer > 0) {
                 std::cout << "[ERROR] Specified layer " << layer << " for adjustment is greater than max routing layer " << _maxRoutingLayer << " and will be ignored" << std::endl;
                 return;
         }


### PR DESCRIPTION
Hello,

Adding layer adjustment was failing because `_maxRoutingLayer` is being set later when FastRoute runs, so I just added a check.

Thanks.